### PR TITLE
Implement LCD-only "Offroad-Mode"

### DIFF
--- a/lcd.c
+++ b/lcd.c
@@ -701,7 +701,7 @@ void walk_assist_state (void)
     {
       motor_controller_data.ui8_walk_assist_level = 1;
       lcd_enable_walk_symbol (1);
-      if (configuration_variables.ui8_odometer_field_state == 1 ) { configuration_variables.ui8_max_speed = 99; } //kts: OffRoad-Mode!
+      if (configuration_variables.ui8_odometer_field_state == 1 ) { configuration_variables.ui8_max_speed = 99; } //Offroad-Mode enabled!
     }
     else
     {
@@ -724,7 +724,7 @@ void odometer (void)
   {
     clear_button_onoff_click_event ();
     configuration_variables.ui8_odometer_field_state = (configuration_variables.ui8_odometer_field_state + 1) % 6;
-    configuration_variables.ui8_max_speed = 25; // kts: get back to OnRoad-Mode
+    configuration_variables.ui8_max_speed = 25; //Offroad-Mode disabled 
   }
 
   switch (configuration_variables.ui8_odometer_field_state)

--- a/lcd.c
+++ b/lcd.c
@@ -702,6 +702,7 @@ void walk_assist_state (void)
     {
       motor_controller_data.ui8_walk_assist_level = 1;
       lcd_enable_walk_symbol (1);
+      if (configuration_variables.ui8_odometer_field_state == 1 ) { configuration_variables.ui8_max_speed = 99; } //kts: OffRoad-Mode!
     }
     else
     {
@@ -724,6 +725,7 @@ void odometer (void)
   {
     clear_button_onoff_click_event ();
     configuration_variables.ui8_odometer_field_state = (configuration_variables.ui8_odometer_field_state + 1) % 6;
+    configuration_variables.ui8_max_speed = 25; // kts: get back to OnRoad-Mode
   }
 
   switch (configuration_variables.ui8_odometer_field_state)


### PR DESCRIPTION
Not yet tested on a live system but should work. Offroad mode can be enabled by selecting "Voltage display" and than holding (-) for 2,5 Seconds to trigger "walking assist mode" which than sets the max-speed to 99. Disabling offroad-mode and setting back to Germany-legal 25 km/h mode with the power-button.

I don't know if the button selection is user friendly; need testing...